### PR TITLE
do not kill the connection on error

### DIFF
--- a/datastreamer/streamserver.go
+++ b/datastreamer/streamserver.go
@@ -41,8 +41,6 @@ const (
 	maxConnections    = 100 // Maximum number of connected clients
 	streamBuffer      = 256 // Buffers for the stream channel
 	maxBookmarkLength = 16  // Maximum number of bytes for a bookmark
-
-	timeout = 2 * time.Second
 )
 
 const (

--- a/datastreamer/streamserver.go
+++ b/datastreamer/streamserver.go
@@ -342,10 +342,7 @@ func (s *StreamServer) handleConnection(conn net.Conn) {
 		log.Debugf("Command %d[%s] received from %s", command, StrCommand[Command(command)], clientID)
 		err = s.processCommand(Command(command), s.getSafeClient(clientID))
 		if err != nil {
-			// Kill client connection
-			time.Sleep(timeout)
-			s.killClient(clientID)
-			return
+			log.Errorf("Error processing command %d[%s] from %s: %v", command, StrCommand[Command(command)], clientID, err)
 		}
 	}
 }


### PR DESCRIPTION
Closes #11

### What does this PR do?

It avoids killing the connection when an error happens. It gets logged and the client already got an error as response.

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @agnusmor 
- @Stefan-Ethernal 