### PR TITLE
Add DS server support for block range download

### DIFF
--- a/datastreamer/errors.go
+++ b/datastreamer/errors.go
@@ -77,6 +77,8 @@ var (
 	ErrStartCommandInvalidParamFromEntry = fmt.Errorf("start command invalid param from entry")
 	// ErrStartBookmarkInvalidParamFromBookmark is returned when the start bookmark is invalid, param from bookmark
 	ErrStartBookmarkInvalidParamFromBookmark = fmt.Errorf("start bookmark invalid param from bookmark")
+	// ErrEndBookmarkInvalidParamToBookmark is returned when the end bookmark is invalid, param to bookmark
+	ErrEndBookmarkInvalidParamToBookmark = fmt.Errorf("end bookmark invalid param to bookmark")
 	// ErrInvalidBinaryResultEntry is returned when the binary result entry is invalid
 	ErrInvalidBinaryResultEntry = fmt.Errorf("invalid binary result entry")
 	// ErrDecodingBinaryResultEntry is returned when there is an error decoding binary result entry

--- a/datastreamer/streamserver.go
+++ b/datastreamer/streamserver.go
@@ -44,12 +44,13 @@ const (
 )
 
 const (
-	CmdStart         Command = iota + 1 // CmdStart for the start from entry TCP client command
-	CmdStop                             // CmdStop for the stop TCP client command
-	CmdHeader                           // CmdHeader for the header TCP client command
-	CmdStartBookmark                    // CmdStartBookmark for the start from bookmark TCP client command
-	CmdEntry                            // CmdEntry for the get entry TCP client command
-	CmdBookmark                         // CmdBookmark for the get bookmark TCP client command
+	CmdStart            Command = iota + 1 // CmdStart for the start from entry TCP client command
+	CmdStop                                // CmdStop for the stop TCP client command
+	CmdHeader                              // CmdHeader for the header TCP client command
+	CmdStartBookmark                       // CmdStartBookmark for the start from bookmark TCP client command
+	CmdStartEndBookmark                    // CmdStartEndBookmark for the start and end from bookmark TCP client command
+	CmdEntry                               // CmdEntry for the get entry TCP client command
+	CmdBookmark                            // CmdBookmark for the get bookmark TCP client command
 )
 
 const (
@@ -58,6 +59,7 @@ const (
 	CmdErrAlreadyStopped                      // CmdErrAlreadyStopped for client already stopped error
 	CmdErrBadFromEntry                        // CmdErrBadFromEntry for invalid starting entry number
 	CmdErrBadFromBookmark                     // CmdErrBadFromBookmark for invalid starting bookmark
+	CmdErrBadToBookmark                       // CmdErrBadToBookmark for invalid to bookmark
 	CmdErrInvalidCommand  CommandError = 9    // CmdErrInvalidCommand for invalid/unknown command error
 )
 
@@ -88,12 +90,13 @@ var (
 
 	// StrCommand for TCP commands description
 	StrCommand = map[Command]string{
-		CmdStart:         "Start",
-		CmdStop:          "Stop",
-		CmdHeader:        "Header",
-		CmdStartBookmark: "StartBookmark",
-		CmdEntry:         "Entry",
-		CmdBookmark:      "Bookmark",
+		CmdStart:            "Start",
+		CmdStop:             "Stop",
+		CmdHeader:           "Header",
+		CmdStartBookmark:    "StartBookmark",
+		CmdStartEndBookmark: "CmdStartEndBookmark",
+		CmdEntry:            "Entry",
+		CmdBookmark:         "Bookmark",
 	}
 
 	// StrCommandErrors for TCP command errors description
@@ -103,6 +106,7 @@ var (
 		CmdErrAlreadyStopped:  "Already stopped",
 		CmdErrBadFromEntry:    "Bad from entry",
 		CmdErrBadFromBookmark: "Bad from bookmark",
+		CmdErrBadToBookmark:   "Bad to bookmark",
 		CmdErrInvalidCommand:  "Invalid command",
 	}
 )
@@ -776,6 +780,9 @@ func (s *StreamServer) processCommand(command Command, client *client) error {
 	case CmdStartBookmark:
 		err = s.handleStartBookmarkCommand(cli)
 
+	case CmdStartEndBookmark:
+		err = s.handleStartEndBookmarkCommand(cli)
+
 	case CmdStop:
 		err = s.handleStopCommand(cli)
 
@@ -826,6 +833,23 @@ func (s *StreamServer) handleStartBookmarkCommand(cli *client) error {
 	err := s.processCmdStartBookmark(cli)
 	if err == nil {
 		cli.status = csSynced
+	}
+
+	return err
+}
+
+// handleStartEndBookmarkCommand processes the CmdStartEndBookmark command
+func (s *StreamServer) handleStartEndBookmarkCommand(cli *client) error {
+	if cli.status != csStopped {
+		log.Error("Stream to client already started!")
+		_ = s.sendResultEntry(uint32(CmdErrAlreadyStarted), StrCommandErrors[CmdErrAlreadyStarted], cli)
+		return ErrClientAlreadyStarted
+	}
+
+	cli.status = csSyncing
+	err := s.processCmdStartEndBookmark(cli)
+	if err == nil {
+		cli.status = csStopped
 	}
 
 	return err
@@ -956,6 +980,51 @@ func (s *StreamServer) processCmdStartBookmark(client *client) error {
 	}
 
 	return err
+}
+
+func (s *StreamServer) processCmdStartEndBookmark(client *client) error {
+	// Read start and end bookmark parameter
+	sb, err := readBookmark(client)
+	if err != nil {
+		return err
+	}
+	eb, err := readBookmark(client)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Client %s command StartEndBookmark start: [%v], end [%v]", client.clientID, sb, eb)
+
+	from, err := s.bookmark.GetBookmark(sb)
+	if err != nil {
+		log.Errorf("StartEndBookmark command invalid start bookmark %v for client %s: %v", sb, client.clientID, err)
+		err = ErrStartBookmarkInvalidParamFromBookmark
+		_ = s.sendResultEntry(uint32(CmdErrBadFromBookmark), StrCommandErrors[CmdErrBadFromBookmark], client)
+		return err
+	}
+	to, err := s.bookmark.GetBookmark(eb)
+	if err != nil || to == 0 {
+		log.Errorf("StartEndBookmark command invalid end bookmark %v for client %s: %v", eb, client.clientID, err)
+		err = ErrEndBookmarkInvalidParamToBookmark
+		_ = s.sendResultEntry(uint32(CmdErrBadToBookmark), StrCommandErrors[CmdErrBadToBookmark], client)
+		return err
+	}
+
+	// Send a command result entry OK
+	err = s.sendResultEntry(0, "OK", client)
+	if err != nil {
+		return err
+	}
+
+	// Send toEntry
+	be := make([]byte, 8)
+	binary.BigEndian.PutUint64(be, to)
+	TimeoutWrite(client, be, s.writeTimeout)
+
+	if from >= s.nextEntry || to >= s.nextEntry {
+		return ErrInvalidBookmarkRange
+	}
+
+	return s.streamingRangeEntry(client, from, to)
 }
 
 // processCmdStop processes the TCP Stop command from the clients
@@ -1137,6 +1206,53 @@ func (s *StreamServer) streamingFromEntry(client *client, fromEntry uint64) erro
 	return nil
 }
 
+// streamingRangeEntry streams the range of file entries until toEntry bookmark (excluding)
+func (s *StreamServer) streamingRangeEntry(client *client, fromEntry uint64, toEntry uint64) error {
+	if fromEntry > toEntry {
+		return ErrInvalidBookmarkRange
+	}
+
+	log.Debugf("SYNCING %s from entry %d to entry %d...", client.clientID, fromEntry, toEntry)
+
+	// Start file stream iterator
+	iterator, err := s.streamFile.iteratorFrom(fromEntry, true)
+	if err != nil {
+		return err
+	}
+
+	// Loop until we reach the to bookmark
+	for {
+		// Get next entry data
+		end, err := s.streamFile.iteratorNext(iterator)
+		if err != nil || end {
+			break
+		}
+
+		// Send the file data entry
+		binaryEntry := encodeFileEntryToBinary(iterator.Entry)
+		log.Debugf("Sending data entry %d (type %d) to %s", iterator.Entry.Number, iterator.Entry.Type, client.clientID)
+		if client.conn != nil {
+			_, err = TimeoutWrite(client, binaryEntry, s.writeTimeout)
+		} else {
+			err = ErrNilConnection
+		}
+		if err != nil {
+			log.Errorf("Error sending entry %d to %s: %v", iterator.Entry.Number, client.clientID, err)
+			return err
+		}
+
+		if iterator.Entry.Number == toEntry {
+			break
+		}
+	}
+	log.Debugf("Synced %s until %d!", client.clientID, iterator.Entry.Number)
+
+	// Close iterator
+	s.streamFile.iteratorEnd(iterator)
+
+	return nil
+}
+
 // sendResultEntry sends the response to a TCP command for the clients
 func (s *StreamServer) sendResultEntry(errorNum uint32, errorStr string, client *client) error {
 	// Prepare the result entry
@@ -1185,6 +1301,29 @@ func (s *StreamServer) BookmarkPrintDump() {
 	if err != nil {
 		log.Errorf("Error dumping bookmark database")
 	}
+}
+
+func readBookmark(client *client) ([]byte, error) {
+	// Read bookmark length parameter
+	length, err := readFullUint32(client)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check maximum length allowed
+	if length > maxBookmarkLength {
+		log.Errorf("Client %s exceeded [%d] maximum allowed length [%d] for a bookmark.",
+			client.clientID, length, maxBookmarkLength)
+		return nil, ErrBookmarkMaxLength
+	}
+
+	// Read start bookmark parameter
+	bookmark, err := readFullBytes(length, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return bookmark, nil
 }
 
 // readFullUint64 reads from a connection a complete uint64


### PR DESCRIPTION
## Summary
### Context
- The current DS server only supports streaming blocks from a specified bookmark point until the latest DS block files
- This will pose issues on the client end since it does not support range range block downloads - if the stream breaks at any point, we cannot deterministically confirm at which point the stream is broken
- On the client end, we cannot guarantee that the de-serialization of the L2 block data, since file entries are nested (for example, L2 transactions in a block)

### Changes
- This PR introduces the new CmdStartEndBookmark that the client can send as a request for a range of blocks, which the server will stream back to the client through the TCP connection from the starting block until the end block (the end block)
- The server on handleConnection will stream back to the client the starting bookmark file entry number
- Client id status on the DS server end will be set to stopped - since the client is not at tip, thus preventing the DS server to broadcast new blocks to the client since it is not at tip (the client themselves should not be using this command if they would want to be remained as synced to the DS server since a specifed end block is sent)